### PR TITLE
fix: logging message when PaymentID is None

### DIFF
--- a/paygate/processors.py
+++ b/paygate/processors.py
@@ -325,13 +325,13 @@ class PayGate(BasePaymentProcessor):
                 (
                     "PayGate checkout: not succeed! "
                     "for basket=%d "
-                    "payment_id=%d "
+                    "payment_id=%s "
                     "return code=%s "
                     "shor error message=%s "
                     "long error message=%s"
                 ),
                 basket.id,
-                payment_id,
+                str(payment_id),
                 return_code,
                 short_return_message,
                 long_return_message
@@ -349,9 +349,9 @@ class PayGate(BasePaymentProcessor):
         success_payment_processor_response.save()
 
         logger.info(
-            "PayGate payment: basket=%d obtained paygate payment id=%d",
+            "PayGate payment: basket=%d obtained paygate payment id=%s",
             basket.id,
-            payment_id,
+            str(payment_id),
         )
 
         parameters = {

--- a/paygate/tests/processors/test_paygate.py
+++ b/paygate/tests/processors/test_paygate.py
@@ -111,6 +111,84 @@ class PayGateTests(PaymentProcessorTestCaseMixin, TestCase):
             basic_auth_pass="APassword",
         )
 
+    def test_get_transaction_parameters_payment_id_none(self):
+        """
+        Test the PayGate `get_transaction_parameters` method, with a `PaymentID` with a `None`
+        value.
+        This method calls the PayGate
+        `checkout` API method, so on this test we need to mock that call, and verify the call has
+        the expected input and verify if the method returns the expected output.
+        """
+        payment_page_url = "https://frontend-test.optimistic.blue/pay"
+        session_token = "A_TOKEN_THAT_WILL_BE_USED"
+
+        # mock the PayGate checkout call
+        with mock.patch.object(
+            PayGate,
+            "_make_api_json_request",
+            return_value={
+                "URL": payment_page_url,
+                "Success": True,
+                "ReturnCode": "XPTO",
+                "ShortReturnMessage": "A short return message",
+                "LongReturnMessage": "A very long return message",
+                "SessionToken": session_token,
+                "PaymentID": None,
+            },
+        ) as mock__make_api_json_request:
+            self.request.LANGUAGE_CODE = "en"
+            self.assertEqual(
+                self.processor.get_transaction_parameters(
+                    self.basket, request=self.request
+                ),
+                {
+                    "payment_page_url": payment_page_url,
+                    "payment_form_data": {
+                        "SessionToken": session_token,
+                    },
+                },
+            )
+
+        mock__make_api_json_request.assert_called_with(
+            "https://test.optimistic.blue/paygateWS/api/CheckOut",
+            method="POST",
+            data={
+                "ACCESS_TOKEN": "PwdX_XXXX_YYYY",
+                "MERCHANT_CODE": "NAU",
+                "IS_RECURRENT": False,
+                "CLIENT_NAME": self.user.full_name,
+                "EMAIL": self.user.email,
+                "LANGUAGE": "en",
+                "PAYMENT_REF": "EDX-100001",
+                "TRANSACTION_DESC": "Seat in Demo Course with test-certificate-type certificate",
+                "CURRENCY": "EUR",
+                "TOTAL_AMOUNT": round(Decimal(20.00), 2),
+                "PAYMENT_TYPES": [
+                    "VISA",
+                    "MASTERCARD",
+                    "AMEX",
+                    "PAYPAL",
+                    "MBWAY",
+                    "REFMB",
+                    "DUC",
+                ],
+                "CALLBACK_SUCCESS_URL": "http://testserver.fake/payment/paygate/callback/success/",
+                "CALLBACK_CANCEL_URL": "http://testserver.fake/payment/paygate/callback/cancel/",
+                "CALLBACK_FAILURE_URL": "http://testserver.fake/payment/paygate/callback/failure/",
+                "CALLBACK_SERVER_URL": "http://testserver.fake/payment/paygate/callback/server/",
+                "CALLBACK_SERVER_PARMS": [
+                    {
+                        "key": "course_id",
+                        "value": "a/b/c",
+                    }
+                ],
+            },
+            basket=self.basket,
+            timeout=10,
+            basic_auth_user="NAU",
+            basic_auth_pass="APassword",
+        )
+
     def test_handle_processor_response(self):
         """
         Test the PayGate `handle_processor_response` method.


### PR DESCRIPTION
Fix a "Logging error"
> TypeError: %d format: a number is required, not NoneType
fixes fccn/ecommerce-plugin-paygate#7