### PR TITLE
fix: remove logging to fix error

### DIFF
--- a/paygate/views.py
+++ b/paygate/views.py
@@ -77,7 +77,7 @@ class PayGateCallbackBaseResponseView(
                 paygate_response = {}
         else:
             paygate_response = request.GET.dict()
-        logger.info("paygate_response: %s", paygate_response)
+        # logger.info("paygate_response: %s", paygate_response)
 
         # ppr = get_object_or_404(PaymentProcessorResponse, id=ppr_id)
 


### PR DESCRIPTION
Remove logging of paygate response.
UnicodeEncodeError: 'ascii' codec can't encode characters in position 246-247: ordinal not in range(128) related to fccn/nau-technical#75