### PR TITLE
feat: add actions to Basket admin improve handling

### DIFF
--- a/paygate/admin.py
+++ b/paygate/admin.py
@@ -1,0 +1,77 @@
+from django.conf import settings
+from django.contrib import admin, messages
+from django.utils.translation import gettext_lazy as _
+from oscar.core.loading import get_model
+from paygate.processors import PayGate
+
+from ecommerce.extensions.basket.admin import BasketAdminExtended
+
+Basket = get_model("basket", "basket")
+
+admin.site.unregister((Basket,))
+
+
+@admin.register(Basket)
+class BasketAdminExtendedPaygate(BasketAdminExtended):
+    """
+    Extended PayGate Basket Django Administration screen with custom actions.
+    """
+
+    @admin.action(description=_("Check if is payed on PayGate"))
+    def check_if_is_payed(self, request, queryset):
+        """
+        Django admin action that permit to check/retry if the basket has been payed on PayGate.
+        """
+        for basket in queryset:
+            site = basket.site
+            paygate = PayGate(site)
+            success = paygate.send_callback_to_itself_to_retry(basket=basket)
+            if success:
+                self.message_user(
+                    request,
+                    _(
+                        "Check if is payed on PayGate with success.",
+                    ),
+                    messages.SUCCESS,
+                )
+            else:
+                self.message_user(
+                    request,
+                    _(
+                        "Check if is payed on PayGate with an error.",
+                    ),
+                    messages.ERROR,
+                )
+
+    @admin.action(description=_("Mark test payment as payed on PayGate"))
+    def mark_test_payment_as_paid(self, request, queryset):
+        """
+        Django admin action that permit to edit Paygate telling the payment has been payed.
+        This method is only available on not production Paygate instances.
+        """
+        for basket in queryset:
+            site = basket.site
+            paygate = PayGate(site)
+            success = paygate.mark_test_payment_as_paid(basket=basket)
+            if success:
+                self.message_user(
+                    request,
+                    _(
+                        "Mark test payment as payed on PayGate with success.",
+                    ),
+                    messages.SUCCESS,
+                )
+            else:
+                self.message_user(
+                    request,
+                    _(
+                        "Mark test payment as payed on PayGate with an error.",
+                    ),
+                    messages.ERROR,
+                )
+
+    actions = [check_if_is_payed] + (
+        [mark_test_payment_as_paid]
+        if getattr(settings, "MARK_TEST_PAYMENT_AS_PAID_ACTION_AVAILABLE", True)
+        else []
+    )

--- a/paygate/settings/test.py
+++ b/paygate/settings/test.py
@@ -12,6 +12,7 @@ PAYMENT_PROCESSOR_CONFIG={
             "merchant_code": "NAU",
             "api_checkout_url": 'https://test.optimistic.blue/paygateWS/api/CheckOut',
             "api_back_search_transactions": "https://test.optimistic.blue/paygateWS/api/BackOfficeSearchTransactions",
+            "mark_test_payment_as_paid_url": "https://test.optimistic.blue/paygateWS/api/MarkTestPaymentAsPaid",
             "api_basic_auth_user": "NAU",
             "api_basic_auth_pass": "APassword",
             "payment_types": ["VISA", "MASTERCARD", "AMEX", "PAYPAL", "MBWAY", "REFMB", "DUC"]
@@ -23,6 +24,7 @@ PAYMENT_PROCESSOR_CONFIG={
             "merchant_code": "other_NAU",
             "api_checkout_url": 'https://test_other.optimistic.blue/paygateWS/api/CheckOut',
             "api_back_search_transactions": "https://test_other.optimistic.blue/paygateWS/api/BackOfficeSearchTransactions",
+            "mark_test_payment_as_paid_url": "https://test_other.optimistic.blue/paygateWS/api/MarkTestPaymentAsPaid",
             "api_basic_auth_user": "other_NAU",
             "api_basic_auth_pass": "other_APassword",
             "payment_types": ["VISA", "MBWAY", "REFMB", "DUC"]


### PR DESCRIPTION
Override the Admin for Basket with custom actions:
- Check if is payed on PayGate
- Mark test payment as payed on PayGate

Improve handling of PayGate payment, don't use received data,
but use the PayGate BackOfficeSearchTransactions response data.

resolves #12
resolves #13