### PR TITLE
fix: integrity error using DUC and improve auditing and logging

### DIFF
--- a/paygate/processors.py
+++ b/paygate/processors.py
@@ -358,9 +358,7 @@ class PayGate(BasePaymentProcessor):
             )
 
             self._raise_api_error(
-                self._raise_api_error(
-                    "Not success", response_data=response_data, basket=basket
-                )
+                "Not success", response_data=response_data, basket=basket
             )
 
         # Save payment processor response

--- a/paygate/processors.py
+++ b/paygate/processors.py
@@ -496,12 +496,12 @@ class PayGate(BasePaymentProcessor):
         # type chosen by the user inside the PayGate.
         transaction_id = paygate_transaction.get("TRANSACTION_ID")
 
-        # Save only a mask of the card
-        card_number = paygate_transaction.get("CARD_MASKED_PAN", "")
-
-        # Payment type (VISA, MASTERCARD, PAYPAL, MBWAY, REFMB,...)
+        # Payment type (VISA, MASTERCARD, PAYPAL, MBWAY, REFMB, DUC, ...)
         # We use the `card_type` to save the payment type used.
-        card_type = paygate_transaction.get("PAYMENT_TYPE_CODE", "")
+        card_type = paygate_transaction.get("PAYMENT_TYPE_CODE", "PayGate")
+
+        # Save only a mask of the card
+        card_number = paygate_transaction.get("CARD_MASKED_PAN", card_type)
 
         return HandledProcessorResponse(
             transaction_id=transaction_id,

--- a/paygate/processors.py
+++ b/paygate/processors.py
@@ -537,6 +537,12 @@ class PayGate(BasePaymentProcessor):
         Execute an API call to the PayGate using an HTTP `method` with some `data` as payload to an
         ecommerce `basket`.
         """
+        if basket:
+            self.record_processor_response(
+                {'url': url, 'timeout': timeout, 'data': data},
+                transaction_id=basket.order_number,
+                basket=basket,
+            )
         requests_func = getattr(requests, method.lower())
 
         # All calls to PayGate require basic authentication has the 1st layer of security.

--- a/paygate/processors.py
+++ b/paygate/processors.py
@@ -470,6 +470,10 @@ class PayGate(BasePaymentProcessor):
             basic_auth_user=self.api_basic_auth_user,
             basic_auth_pass=self.api_basic_auth_pass,
         )
+        logger.info(
+            "Search Transactions on PayGate received the response data: [%s]",
+            search_response_data,
+        )
         confirmed_payed_on_paygate = False
         # it should be a single item that have been payed
         if len(search_response_data) == 1:
@@ -701,8 +705,8 @@ class PayGate(BasePaymentProcessor):
 
     def mark_test_payment_as_paid(self, basket=None) -> bool:
         """
-        Make a Paygate payment as paid on Paygate.
-        This action is only available on testing instances of Paygate.
+        Make a PayGate payment as paid on PayGate.
+        This action is only available on testing instances of PayGate.
         """
         payment_ref = basket.order_number
         request_data = {
@@ -722,5 +726,6 @@ class PayGate(BasePaymentProcessor):
                 basic_auth_pass=self.api_basic_auth_pass,
             )
             return True
-        except GatewayError:
+        except GatewayError as ge:
+            logger.warning("GatewayError error when mark_test_payment_as_paid [%s]", ge)
             return False


### PR DESCRIPTION
feat: improve auditing and logging

Record PayGate calls specific to a Basket as a processor response,
so we can better audit and trace all calls to PayGate as a fake
response.

feat: add more logging

fix: double raising error

fix: integrity error using DUC

When handing a payment, and double checking that the
payment as been payed on PayGate, the card number
`CARD_MASKED_PAN` is empty/null for DUC payments.
The card number nullable crashes Ecommerce.
