### PR TITLE
fix: integrity error for DUC

### DIFF
--- a/paygate/processors.py
+++ b/paygate/processors.py
@@ -500,10 +500,12 @@ class PayGate(BasePaymentProcessor):
 
         # Payment type (VISA, MASTERCARD, PAYPAL, MBWAY, REFMB, DUC, ...)
         # We use the `card_type` to save the payment type used.
-        card_type = paygate_transaction.get("PAYMENT_TYPE_CODE", "PayGate")
+        card_type = paygate_transaction.get("PAYMENT_TYPE_CODE")
 
         # Save only a mask of the card
-        card_number = paygate_transaction.get("CARD_MASKED_PAN", card_type)
+        card_number = paygate_transaction.get("CARD_MASKED_PAN")
+        if not card_number:
+            card_number = card_type
 
         hpr = HandledProcessorResponse(
             transaction_id=transaction_id,


### PR DESCRIPTION
When receiving a payment paid from a DUC,
there isn't any card masked pan, so we
fall back to save only the payment type.
fixes #15